### PR TITLE
Replace pymsteams with apprise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__
 Attic
 dist
 htmlcov
+.venv
+venv

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ ALPHA-VERSION!
 This is a plugin to send notifications to MSTeams from
 `Argus <https://github.com/Uninett/argus-server>`_
 
-Different levels of incidents have hard-coded colors.
+Different levels of incidents have hard-coded icon colors, based on those used in the Argus frontend.
 
 Version 0.5.1 and older can be used by argus-server version 1.9.x to 1.13.x.
 
@@ -25,7 +25,8 @@ The plugin uses the setting ``NOTIFICATION_SUBJECT_PREFIX``.
 Configuration
 -------------
 
-Create a webhook inside MS Teams, which results in a long url that needs to be
+Create a workflow inside MS team to send webhook alerts to a chat or channel.
+This lets you use "Copy webhook link" to get a long url that needs to be
 stored in the ``settings``-field.
 
 You can test without invoking the frontend by adding the webhook manually in

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ argus_notification_msteams
 This is a plugin to send notifications to MSTeams from
 `Argus <https://github.com/Uninett/argus-server>`_
 
-cdDifferent levels of incidents have hard-coded icon colors, based on those used in the Argus frontend.
+Different levels of incidents have hard-coded icon colors, based on those used in the Argus frontend.
 
 Version 0.5.1 and older can be used by argus-server version 1.9.x to 1.13.x.
 
@@ -23,7 +23,7 @@ The plugin uses the setting ``NOTIFICATION_SUBJECT_PREFIX``.
 Configuration
 -------------
 
-Create a workflow inside MS team to send webhook alerts to a chat or channel.
+Create a workflow inside MS Teams to send webhook alerts to a chat or channel.
 This lets you use "Copy webhook link" to get a long url that needs to be
 stored in the ``settings``-field.
 

--- a/README.rst
+++ b/README.rst
@@ -1,12 +1,10 @@
 argus_notification_msteams
 ==========================
 
-ALPHA-VERSION!
-
 This is a plugin to send notifications to MSTeams from
 `Argus <https://github.com/Uninett/argus-server>`_
 
-Different levels of incidents have hard-coded icon colors, based on those used in the Argus frontend.
+cdDifferent levels of incidents have hard-coded icon colors, based on those used in the Argus frontend.
 
 Version 0.5.1 and older can be used by argus-server version 1.9.x to 1.13.x.
 

--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -2,10 +2,12 @@
 ==============
 **1.0.0**
 
-For version 1, we replaced the dependency ``pymsteams`` with ``appraise``.
+For version 1, we replaced the dependency ``pymsteams`` with ``apprise``.
 
-After upgrading, the ``pymsteams`` library may be cleaned away using ``pip uninstall pymsteams`` or something similar.
+This is because how things are shared with MS Teams have changed completely,
+which also means that a new MS Teams workflow needs to be created in place of
+any existing webhooks. See the **README** for instructions.
 
-This also means that a new MS Teams workflow needs to be created in place of any existing webhooks.
-See the **README** for instructions.
+After upgrading, the ``pymsteams`` library may be cleaned away using ``pip
+uninstall pymsteams`` or something similar.
 

--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -1,0 +1,11 @@
+**UPGRADING**
+==============
+**1.0.0**
+
+For version 1, we replaced the dependency ``pymsteams`` with ``appraise``.
+
+When upgrading ``pymsteams`` might need to be removed using ``pip-recipe`` or similar.
+
+This also means that a new teams workflow needs to be created in place of any existing webhooks.
+See the **README** for instructions.
+

--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -4,7 +4,7 @@
 
 For version 1, we replaced the dependency ``pymsteams`` with ``appraise``.
 
-When upgrading, ``pymsteams`` might need to be removed using ``pip-recipe`` or something similar.
+After upgrading, the ``pymsteams`` library may be cleaned away using ``pip uninstall pymsteams`` or something similar.
 
 This also means that a new MS Teams workflow needs to be created in place of any existing webhooks.
 See the **README** for instructions.

--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -4,8 +4,8 @@
 
 For version 1, we replaced the dependency ``pymsteams`` with ``appraise``.
 
-When upgrading ``pymsteams`` might need to be removed using ``pip-recipe`` or similar.
+When upgrading, ``pymsteams`` might need to be removed using ``pip-recipe`` or something similar.
 
-This also means that a new teams workflow needs to be created in place of any existing webhooks.
+This also means that a new MS Teams workflow needs to be created in place of any existing webhooks.
 See the **README** for instructions.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [{name = "Hanne Moa", email = "hanne.moa@sikt.no"}]
 maintainers = [{name = "Hanne Moa", email = "hanne.moa@sikt.no"}]
 dependencies = [
     "argus-server>=1.14.0",
-    "pymsteams>=0.2",
+    "apprise>=1.9.6",
 ]
 requires-python = ">=3.8"
 classifiers = [

--- a/src/argus_notification_msteams.py
+++ b/src/argus_notification_msteams.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 LOG = logging.getLogger(__name__)
 
-__version__ = "0.7.0"
+__version__ = "1.0.0"
 __all__ = [
     "MSTeamsNotification",
 ]

--- a/tests/test_msteams.py
+++ b/tests/test_msteams.py
@@ -1,8 +1,8 @@
-from django.conf import settings
-from django.test import TestCase, SimpleTestCase
+#from django.conf import settings
+#from django.test import TestCase, SimpleTestCase
 
-from argus.incident.factories import IncidentFactory
-from argus_notification_msteams import _build_card, _build_context, MSTeamsNotification
+#from argus.incident.factories import IncidentFactory
+#from argus_notification_msteams import _build_context, MSTeamsNotification
 
 
 # class TestHelperFunctions(TestCase):
@@ -38,28 +38,3 @@ from argus_notification_msteams import _build_card, _build_context, MSTeamsNotif
 #     def test__build_context_level_is_incident_level(self):
 #         context = _build_context(self.event)
 #         self.assertEqual(context["level"], self.event.incident.level)
-
-
-class TestCardBuilder(SimpleTestCase):
-
-    def test___build_card(self):
-        context = {
-            "subject": "test",
-            "title": "title",
-            "status": "STA",
-            "expiration": "2022-11-178T11:46+01:00",
-            "level": 3,
-            "actor": "tester@eaxmple.com",
-            "message": "this is a test notification!",
-            "incident_dict": {
-                "key1": "value1",
-            },
-        }
-        webhook = "https://example.org/"
-        card = _build_card(webhook, context)
-        self.assertEqual(card.hookurl, webhook)
-        self.assertEqual(card.payload["title"], context["subject"])
-        # One section
-        self.assertEqual(len(card.payload["sections"]), 1)
-        # Only containing facts
-        self.assertIn("facts", card.payload["sections"][0].keys())

--- a/tests/test_msteams.py
+++ b/tests/test_msteams.py
@@ -1,8 +1,8 @@
 #from django.conf import settings
-#from django.test import TestCase, SimpleTestCase
+from django.test import SimpleTestCase
 
 #from argus.incident.factories import IncidentFactory
-#from argus_notification_msteams import _build_context, MSTeamsNotification
+from argus_notification_msteams import _build_message
 
 
 # class TestHelperFunctions(TestCase):
@@ -38,3 +38,30 @@
 #     def test__build_context_level_is_incident_level(self):
 #         context = _build_context(self.event)
 #         self.assertEqual(context["level"], self.event.incident.level)
+
+
+class TestMessageBuilder(SimpleTestCase):
+
+    def test_build_message(self):
+        context = {
+            "subject": "test",
+            "title": "title",
+            "status": "STA",
+            "expiration": "2022-11-178T11:46+01:00",
+            "level": 3,
+            "actor": "tester@eaxmple.com",
+            "message": "this is a test notification!",
+            "incident_dict": {
+                "key1": "value1",
+                "key2": "value2",
+            },
+        }
+        message = _build_message(context)
+        self.assertIn("**test**", message)
+        self.assertIn("this is a test notification!", message)
+        self.assertIn("**Status** STA", message)
+        self.assertIn("**Actor** tester@eaxmple.com", message)
+        self.assertIn("**Expires** 2022-11-178T11:46+01:00", message)
+        self.assertIn("**key1** value1", message)
+        self.assertIn("**key2** value2", message)
+

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -15,6 +15,7 @@ INSTALLED_APPS = [
     'argus.auth',
     'argus.incident',
     'argus.notificationprofile',
+    'argus.plannedmaintenance'
 ]
 
 DATABASES = {


### PR DESCRIPTION
Fixes #1 

Formatting is similar to before but not identical, see pictures:
Before:
<img width="884" height="408" alt="bilde" src="https://github.com/user-attachments/assets/8a6e4663-68a1-4e0d-a10f-c3c17ccdbb14" />
After:
<img width="875" height="473" alt="bilde" src="https://github.com/user-attachments/assets/d17a3120-b0ee-453d-8b84-166f204a4c22" />

Note that the icon on the top of the new message tries to match the level color used in Argus, with the only deviation being that level 3 and 2 will both be orange since yellow is not supported. This color scheme is different to the existing one used by the notifications.
